### PR TITLE
Enable using location search with shorter place names

### DIFF
--- a/src/components/filters/location.js
+++ b/src/components/filters/location.js
@@ -149,7 +149,7 @@ export class LocationSelect extends React.PureComponent {
   };
 
   getAsyncOptions = (input: string, cb: (e: ?Error, any) => void) => {
-    if (input.length >= 3) {
+    if (input.length >= 2) {
       return nominatimSearch(input, this.state.queryType)
         .then(json => {
           if (!Array.isArray(json)) return cb(null, { options: [] });

--- a/src/components/filters/location.js
+++ b/src/components/filters/location.js
@@ -149,7 +149,7 @@ export class LocationSelect extends React.PureComponent {
   };
 
   getAsyncOptions = (input: string, cb: (e: ?Error, any) => void) => {
-    if (input.length >= 2) {
+    if (input.length >= 2 || this.isOneCharInputAllowed(input)) {
       return nominatimSearch(input, this.state.queryType)
         .then(json => {
           if (!Array.isArray(json)) return cb(null, { options: [] });
@@ -163,6 +163,18 @@ export class LocationSelect extends React.PureComponent {
         .catch(e => cb(e, null));
     } else {
       return cb(null, { options: [] });
+    }
+  };
+  isOneCharInputAllowed = (input: string) => {
+    // Allowing one character input if it contains characters from certain scripts while
+    // guarding against browsers that don't support this kind of regular expression
+    try {
+      return /\p{scx=Han}|\p{scx=Hangul}|\p{scx=Hiragana}|\p{scx=Katakana}/u.test(
+        input
+      );
+    } catch {
+      // Allowing always is better than never allowing for the above-mentioned scripts
+      return true;
     }
   };
   onChangeLocal = (data: ?Array<Object>) => {


### PR DESCRIPTION
This is the first attempt at fixing problems with location search when Chinese or other similar languages are used. Please see commit messages for details.

Related issue is: https://github.com/mapbox/osmcha-frontend/issues/538

Tested manually on both Firefox and Brave. It looks like the used select component has more strange issues. Was not able to fix those but also checked that I didn't create more issues. The react-select version is quite old: `^1.0.0-rc.5` in `package.json` while latest release is 5.7.3.