### PR TITLE
Dockerfile to serve the frontend through nginx

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,50 @@
+name: Build Docker Image, Push to GHCR
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker image for production
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        push: true
+        tags: |
+          ghcr.io/osmcha/osmcha-frontend:latest
+          ghcr.io/osmcha/osmcha-frontend:${{ github.sha }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Build and push Docker image for test instance at osmcha-test.ds.io
+      uses: docker/build-push-action@v4
+      with:
+        # Pass the build environment as a build argument. Ensures that the correct
+        # hostname is used in the frontend.
+        # Todo: There's probably a better way to do this than building separate images
+        build-args: BUILD_ENV=test
+        context: .
+        push: true
+        tags: |
+          ghcr.io/osmcha/osmcha-frontend-test:latest
+          ghcr.io/osmcha/osmcha-frontend-test:${{ github.sha }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:16-slim as builder
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ARG BUILD_ENV=prod
+
+RUN mkdir /app
+WORKDIR /app
+COPY package.json /app
+COPY yarn.lock /app
+RUN yarn install
+
+COPY . /app/
+ENV REACT_APP_PRODUCTION_API_URL /api/v1
+RUN yarn build:${BUILD_ENV}
+
+FROM nginx:alpine
+COPY --from=builder /app/build /assets

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "build:staging": "REACT_APP_VERSION=\"$(node -e \"console.log(require('./package.json').version)\")\" REACT_APP_STACK=STAGING PUBLIC_URL=https://staging.osmcha.org react-scripts build",
     "deploy:staging": "gh-pages -d build -b oh-pages",
     "build:prod": "REACT_APP_VERSION=\"$(node -e \"console.log(require('./package.json').version)\")\" REACT_APP_STACK=PRODUCTION PUBLIC_URL=https://osmcha.org react-scripts build",
-    "deploy:prod": "gh-pages -d build -b oh-pages"
+    "deploy:prod": "gh-pages -d build -b oh-pages",
+    "build:test": "REACT_APP_VERSION=\"$(node -e \"console.log(require('./package.json').version)\")\" REACT_APP_STACK=PRODUCTION PUBLIC_URL=https://osmcha-test.ds.io react-scripts build"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
Builds and publishes an nginx image with the OSMCha frontend application to GHCR. Images are tagged by commit ids. We publish separate images - one for production (ghcr.io/osmcha/osmcha-frontend) and one for the test instance (ghcr.io/osmcha/osmcha-frontend-test) for now.