### PR TITLE
Replace Mapbox Code of Conduct with OSM US one

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,5 +1,0 @@
-# Code of conduct
-
-Everyone is invited to participate in Mapbox’s open source projects and public discussions: we want to create a welcoming and friendly environment. Harassment of participants or other unethical and unprofessional behavior will not be tolerated in our spaces. The [Contributor Covenant](https://www.contributor-covenant.org/) applies to all projects under the Mapbox organization and we ask that you please read [the full text](https://www.contributor-covenant.org/version/1/2/0/code-of-conduct/).
-
-You can learn more about our open source philosophy on [mapbox.com](https://www.mapbox.com/about/open/).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+
+# Code of Conduct
+
+This project follows the [OpenStreetMap US Code of Conduct](https://wiki.openstreetmap.org/wiki/Foundation/Local_Chapters/United_States/Code_of_Conduct_Committee/OSM_US_Code_of_Conduct)
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ The current OSMCHA is broken into two repositories. You can file bug in any of t
 ## Code of Conduct
 
 Please read the project
-[Code of Conduct](CODE-OF-CONDUCT.md) and remember to be nice to one another.
+[Code of Conduct](CODE_OF_CONDUCT.md) and remember to be nice to one another.
 
 ## Reporting Issues
 


### PR DESCRIPTION
Since OSMCha is an [OpenStreetMap US Charter Project](https://openstreetmap.us/news/2024/03/OSMCha-new-home/), it follows the [OSM US Code of Conduct](https://wiki.openstreetmap.org/wiki/Foundation/Local_Chapters/United_States/Code_of_Conduct_Committee/OSM_US_Code_of_Conduct).

This PR removes the obsolete link to the Mapbox Code of Conduct that previously applied to this project, and adds a link to the OSM US Code of Conduct in its place.