### PR TITLE
Remove CircleCI badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # osmcha-frontend
-[![CircleCI](https://circleci.com/gh/mapbox/osmcha-frontend.svg?style=svg)](https://circleci.com/gh/mapbox/osmcha-frontend)
 
 OSMCha is composed by a group of softwares that together has the aim to make it
 easier to monitor and validate the changes in OpenStreetMap. [Learn more …](ABOUT.md)

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  node:
-    version: 7


### PR DESCRIPTION
This project isn't built using CircleCI anymore; CI builds now use [Github Actions](https://github.com/OSMCha/osmcha-frontend/actions).