### PR TITLE
Remove test image from GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -2,8 +2,14 @@ name: Build Docker Image, Push to GHCR
 
 on:
   push:
-    branches:
-    - master
+    # Publish HEAD of main branch as :latest image tag
+    branches: [ "main" ]
+    # Publish semver tags as named image tags
+    tags: [ 'v*.*.*' ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: osmcha/osmcha-frontend
 
 jobs:
   build:
@@ -11,40 +17,37 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
+    # Enable BuildKit for docker builds. This enables building
+    # multi-platform images and exporting the layer cache
+    # https://github.com/docker/setup-buildx-action
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
 
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+    # https://github.com/docker/login-action
+    - name: Login to Registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v3
       with:
-        registry: ghcr.io
+        registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and push Docker image for production
-      uses: docker/build-push-action@v4
+    # Extract metadata (tags, labels) for Docker
+    # https://github.com/docker/metadata-action
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@v5
       with:
-        context: .
-        push: true
-        tags: |
-          ghcr.io/osmcha/osmcha-frontend:latest
-          ghcr.io/osmcha/osmcha-frontend:${{ github.sha }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-    - name: Build and push Docker image for test instance at osmcha-test.ds.io
-      uses: docker/build-push-action@v4
+    # https://github.com/docker/build-push-action
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
       with:
-        # Pass the build environment as a build argument. Ensures that the correct
-        # hostname is used in the frontend.
-        # Todo: There's probably a better way to do this than building separate images
-        build-args: BUILD_ENV=test
         context: .
         push: true
-        tags: |
-          ghcr.io/osmcha/osmcha-frontend-test:latest
-          ghcr.io/osmcha/osmcha-frontend-test:${{ github.sha }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max


### PR DESCRIPTION
This should fix the build failure introduced in #749. It also bumps the versions of various actions and adds labels to container images to match any semver tags (a git tag `v1.2.3` creates an image labeled `osmcha/osmcha-frontend:1.2.3`).