### PR TITLE
Add dir='auto' to tag values in Tag Changes view to correctly display RTL text

### DIFF
--- a/src/components/changeset/tag_changes.js
+++ b/src/components/changeset/tag_changes.js
@@ -107,11 +107,17 @@ function ChangeTitle({ value, type }) {
   }
   if (type.startsWith('Changed')) {
     const [oldValue, newValue] = value;
+    // dir="auto" solves a display issue when tag values are in RTL scripts (e.g. Arabic, Hebrew).
+    // See https://github.com/OSMCha/osmcha-frontend/issues/765
     return (
       <span>
-        <span className="txt-code cmap-bg-modify-old-light">{oldValue}</span>
+        <span className="txt-code cmap-bg-modify-old-light" dir="auto">
+          {oldValue}
+        </span>
         <strong> ➜ </strong>
-        <span className="txt-code cmap-bg-modify-new-light">{newValue}</span>
+        <span className="txt-code cmap-bg-modify-new-light" dir="auto">
+          {newValue}
+        </span>
       </span>
     );
   }


### PR DESCRIPTION
Fixes #765

<img width="635" alt="image" src="https://github.com/user-attachments/assets/51a57c83-56c7-46b4-8809-09ddef8a7531" />
