### PR TITLE
Fix bug preventing paginator from working on first load

### DIFF
--- a/src/components/relative_time.js
+++ b/src/components/relative_time.js
@@ -3,7 +3,7 @@ import { formatDistanceToNow } from 'date-fns';
 
 export function RelativeTime({ datetime, addSuffix = true }: Object) {
   return (
-    <time datetime={datetime.toISOString()} title={datetime.toString()}>
+    <time dateTime={datetime.toISOString()} title={datetime.toString()}>
       {formatDistanceToNow(datetime, { addSuffix })}
     </time>
   );

--- a/src/store/changesets_page_actions.js
+++ b/src/store/changesets_page_actions.js
@@ -50,9 +50,8 @@ export const locationSelector = (state: RootStateType) =>
 
 /** Sagas **/
 
-export const pageIndexSelector = (state: RootStateType) => [
-  state.changesetsPage.getIn(['pageIndex'], 0)
-];
+export const pageIndexSelector = (state: RootStateType) =>
+  state.changesetsPage.getIn(['pageIndex'], 0);
 export const tokenSelector = (state: RootStateType) => state.auth.get('token');
 
 export const aoiIdSelector = (state: RootStateType) =>


### PR DESCRIPTION
This PR fixes a bug in the paginator widget where the prev/next arrows did not work after initial page load, and would only start working once you clicked on a specific page number (e.g '2'). Turns out this was due to some accidental `[]` in a Redux selector which was causing certain code paths to turn `pageIndex` into an array instead of a number.

It also fixes an unrelated console warning from React