### PR TITLE
Preserve order of relation members in element info table

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "buffer": "^6.0.3",
     "date-fns": "^2.22.1",
     "deep-equal": "^2.2.3",
+    "diff": "^7.0.0",
     "dompurify": "^3.0.3",
     "history": "^4.10.1",
     "immutable": "^3.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5318,6 +5318,11 @@ diff-sequences@^27.5.1:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
   integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
 
+diff@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-7.0.0.tgz#3fb34d387cd76d803f6eebea67b921dab0182a9a"
+  integrity sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"


### PR DESCRIPTION
Relation membership order is semantically significant in some types of relations (e.g. route relations), so this change ensures that the original order is preserved when listing members in the element info panel (previously they were shown sorted by element ID).

