### PR TITLE
Fix display of RTL tag and role values in element info table

### DIFF
--- a/src/components/element_info.js
+++ b/src/components/element_info.js
@@ -259,7 +259,9 @@ function TagsTable({ action }) {
           if (oldval === newval) {
             return (
               <tr>
-                <td>{key}</td>
+                <td>
+                  <span dir="auto">{key}</span>
+                </td>
                 <td>
                   <span dir="auto">{newval}</span>
                 </td>
@@ -268,7 +270,9 @@ function TagsTable({ action }) {
           } else if (oldval === undefined) {
             return (
               <tr className="create">
-                <td>{key}</td>
+                <td>
+                  <span dir="auto">{key}</span>
+                </td>
                 <td>
                   <span dir="auto">{newval}</span>
                 </td>
@@ -277,7 +281,9 @@ function TagsTable({ action }) {
           } else if (newval === undefined) {
             return (
               <tr className="delete">
-                <td>{key}</td>
+                <td>
+                  <span dir="auto">{key}</span>
+                </td>
                 <td>
                   <span dir="auto">{oldval}</span>
                 </td>
@@ -286,7 +292,9 @@ function TagsTable({ action }) {
           } else {
             return (
               <tr className="modify">
-                <td>{key}</td>
+                <td>
+                  <span dir="auto">{key}</span>
+                </td>
                 <td>
                   <del dir="auto">{oldval}</del>
                   {' → '}

--- a/src/components/element_info.js
+++ b/src/components/element_info.js
@@ -260,21 +260,27 @@ function TagsTable({ action }) {
             return (
               <tr>
                 <td>{key}</td>
-                <td>{newval}</td>
+                <td>
+                  <span dir="auto">{newval}</span>
+                </td>
               </tr>
             );
           } else if (oldval === undefined) {
             return (
               <tr className="create">
                 <td>{key}</td>
-                <td>{newval}</td>
+                <td>
+                  <span dir="auto">{newval}</span>
+                </td>
               </tr>
             );
           } else if (newval === undefined) {
             return (
               <tr className="delete">
                 <td>{key}</td>
-                <td>{oldval}</td>
+                <td>
+                  <span dir="auto">{oldval}</span>
+                </td>
               </tr>
             );
           } else {
@@ -282,9 +288,9 @@ function TagsTable({ action }) {
               <tr className="modify">
                 <td>{key}</td>
                 <td>
-                  <del>{oldval}</del>
+                  <del dir="auto">{oldval}</del>
                   {' → '}
-                  <ins>{newval}</ins>
+                  <ins dir="auto">{newval}</ins>
                 </td>
               </tr>
             );
@@ -332,21 +338,27 @@ function RelationMembersTable({ action, setHighlight }) {
             return (
               <tr {...interactions}>
                 <td>{id}</td>
-                <td>{newrole}</td>
+                <td>
+                  <span dir="auto">{newrole}</span>
+                </td>
               </tr>
             );
           } else if (oldrole === undefined) {
             return (
               <tr className="create" {...interactions}>
                 <td>{id}</td>
-                <td>{newrole}</td>
+                <td>
+                  <span dir="auto">{newrole}</span>
+                </td>
               </tr>
             );
           } else if (newrole === undefined) {
             return (
               <tr className="delete" {...interactions}>
                 <td>{id}</td>
-                <td>{oldrole}</td>
+                <td>
+                  <span dir="auto">{oldrole}</span>
+                </td>
               </tr>
             );
           } else {
@@ -354,9 +366,9 @@ function RelationMembersTable({ action, setHighlight }) {
               <tr className="modify" {...interactions}>
                 <td>{id}</td>
                 <td>
-                  <del>{oldrole}</del>
+                  <del dir="auto">{oldrole}</del>
                   {' → '}
-                  <ins>{newrole}</ins>
+                  <ins dir="auto">{newrole}</ins>
                 </td>
               </tr>
             );


### PR DESCRIPTION
Fixes #789

The additional `<span>` elements inside the `<td>` elements are necessary to make the table render in the desired layout. In an RTL context, the `::before` pseudo-element comes at the right, so if the `td` itself were RTL then the `=` sign separating the key and value would instead come at the very end (right side) of the table row.