### PR TITLE
Add GitHub issue template forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,31 @@
+name: Bug report
+description: Let us know if you've found a bug in OSMCha
+labels: ["bug"]
+body:
+  - type: textarea
+    id: describe-bug
+    attributes:
+      label: Describe the bug
+      description: Be as clear and concise as you can. Include steps to reproduce the bug if necessary.
+    validations:
+      required: true
+
+  - type: input
+    id: changeset-url
+    attributes:
+      label: Changeset URL
+      description: If this bug happens when viewing a particular changeset, please paste the link to that changeset here
+    
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Your browser (including version) and operating system (e.g. "Chrome 137 on macOS")
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional information
+      description: Screenshots, console logs, or any other details that might help us understand the issue (optional)

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,17 @@
+name: Feature request
+description: Suggest a new feature for OSMCha
+labels: [enhancement]
+body:
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: What feature would you like to see added?
+    validations:
+      required: true
+
+  - type: textarea
+    id: feature-value
+    attributes:
+      label: Why would this be useful to you or other users?
+    validations:
+      required: true


### PR DESCRIPTION
Adds template forms for GitHub issues on the OSMCha frontend repo. This helps prompt someone who's reporting an issue to provide relevant info. I kept the number of required fields low, and the descriptions brief, so that the form wouldn't be a barrier to anyone wanting to create a new issue.

Bug report form:

![Screenshot 2025-05-08 at 12-59-24 New Issue](https://github.com/user-attachments/assets/c43cbd5d-79fb-4132-819e-ec4961e4cfb0)

Feature request form:

![Screenshot 2025-05-08 at 12-59-39 New Issue](https://github.com/user-attachments/assets/d06a4515-51b6-4ca4-a777-9d460a53b499)

In addition, you can still choose a "blank" issue from the template list.