### PR TITLE
Fix blank page when loading a changeset while not logged in

### DIFF
--- a/src/views/map.js
+++ b/src/views/map.js
@@ -110,7 +110,7 @@ class CMap extends React.PureComponent {
   }
 
   initializeMap() {
-    if (!this.props.changeset) {
+    if (!this.props.token || !this.props.changeset) {
       return;
     }
 


### PR DESCRIPTION
Fixes #795.

If the user is not logged in, `initializeMap()` will now do nothing. This prevents it from attempting to attach a MapLibre map to a container element that does not exist, which throws an uncaught error and results in the entire page becoming blank.