### PR TITLE
Remove plausible analytics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,9 +17,6 @@
 
 <body>
   <div id="root"></div>
-  <!-- Plausible Web Analytics -->
-  <script defer data-domain="osmcha.org" src="https://plausible.io/js/script.js"></script>
-  <!-- End Plausible Web Analytics -->
 </body>
 
 </html>


### PR DESCRIPTION
OSMCha is spending almost the entire plausible tracking quota paid by DevSeed, so we need to remove it, unfortunately.