### PR TITLE
Add Esri imagery basemap sources

### DIFF
--- a/src/components/changeset/map_options.js
+++ b/src/components/changeset/map_options.js
@@ -24,7 +24,9 @@ const toggle = (arr, elem) => {
 
 class MapOptions extends React.PureComponent {
   layerOptions = [
-    { label: 'Bing aerial imagery', value: 'bing' },
+    { label: 'Bing Maps Aerial', value: 'bing' },
+    { label: 'Esri World Imagery', value: 'esri' },
+    { label: 'Esri World Imagery (Clarity) Beta', value: 'esri-clarity' },
     { label: 'OpenStreetMap Carto', value: 'carto' }
   ];
 

--- a/src/views/map.js
+++ b/src/views/map.js
@@ -15,6 +15,7 @@ const BING_AERIAL_IMAGERY_STYLE = {
   sources: {
     bing: {
       type: 'raster',
+      scheme: 'xyz',
       tiles: [
         'https://ecn.t0.tiles.virtualearth.net/tiles/a{quadkey}.jpeg?g=587&mkt=en-gb&n=z',
         'https://ecn.t1.tiles.virtualearth.net/tiles/a{quadkey}.jpeg?g=587&mkt=en-gb&n=z',
@@ -31,6 +32,53 @@ const BING_AERIAL_IMAGERY_STYLE = {
       id: 'imagery',
       type: 'raster',
       source: 'bing'
+    }
+  ]
+};
+
+const ESRI_WORLD_IMAGERY_STYLE = {
+  version: 8,
+  sources: {
+    esri: {
+      type: 'raster',
+      scheme: 'xyz',
+      tiles: [
+        'https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}?blankTile=false',
+        'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}?blankTile=false'
+      ],
+      tileSize: 256,
+      maxzoom: 20,
+      attribution: 'Imagery © Esri'
+    }
+  },
+  layers: [
+    {
+      id: 'imagery',
+      type: 'raster',
+      source: 'esri'
+    }
+  ]
+};
+
+const ESRI_WORLD_IMAGERY_CLARITY_STYLE = {
+  version: 8,
+  sources: {
+    esri: {
+      type: 'raster',
+      scheme: 'xyz',
+      tiles: [
+        'https://clarity.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}?blankTile=false'
+      ],
+      tileSize: 256,
+      maxzoom: 20,
+      attribution: 'Imagery © Esri'
+    }
+  },
+  layers: [
+    {
+      id: 'imagery',
+      type: 'raster',
+      source: 'esri'
     }
   ]
 };
@@ -60,6 +108,15 @@ const OPENSTREETMAP_CARTO_STYLE = {
     }
   ]
 };
+
+const BASEMAP_STYLES = {
+  bing: BING_AERIAL_IMAGERY_STYLE,
+  esri: ESRI_WORLD_IMAGERY_STYLE,
+  'esri-clarity': ESRI_WORLD_IMAGERY_CLARITY_STYLE,
+  carto: OPENSTREETMAP_CARTO_STYLE
+};
+
+const DEFAULT_BASEMAP_STYLE = BING_AERIAL_IMAGERY_STYLE;
 
 class CMap extends React.PureComponent {
   props: {
@@ -120,11 +177,7 @@ class CMap extends React.PureComponent {
       this.map.remove();
     }
 
-    let style = BING_AERIAL_IMAGERY_STYLE;
-
-    if (this.props.style === 'carto') {
-      style = OPENSTREETMAP_CARTO_STYLE;
-    }
+    let style = BASEMAP_STYLES[this.props.style] ?? DEFAULT_BASEMAP_STYLE;
 
     let map = new maplibre.Map({
       container,
@@ -194,11 +247,7 @@ class CMap extends React.PureComponent {
   updateMap() {
     if (this.state.loading || !this.map || !this.adiffViewer) return;
 
-    let style = BING_AERIAL_IMAGERY_STYLE;
-
-    if (this.props.style === 'carto') {
-      style = OPENSTREETMAP_CARTO_STYLE;
-    }
+    let style = BASEMAP_STYLES[this.props.style] ?? DEFAULT_BASEMAP_STYLE;
 
     this.map.setStyle(style);
 


### PR DESCRIPTION
Resolves #764

Esri's [permitted uses statement](https://www.arcgis.com/home/item.html?id=8e90a00a0a6845a49262e0b756f57a10) for their imagery products allows us to use their imagery in OSMCha (emphasis mine):

> Esri and its imagery contributors grant Users the non-exclusive right to use the World Imagery map to trace features and **validate edits** in the creation of vector data. Users that create vector data from the World Imagery map can publicly share that vector data through a GIS data clearinghouse of their own or through another open data site. Public sharing can also be achieved through ArcGIS Open Data or the OpenStreetMap (OSM) Initiative. For ArcGIS users that want to contribute such vector data to OSM, Esri provides applications and services directly accessible from ArcGIS platform. Users acknowledge that any vector data contributed to OSM is then governed by and released under the OpenStreetMap License (e.g. ODbL).

...which is pretty cool. If anyone at Esri is reading this, thanks!