### PR TITLE
Fix location search in filter UI (add the geometry to the filter params)

### DIFF
--- a/src/components/filters/location.js
+++ b/src/components/filters/location.js
@@ -206,13 +206,19 @@ const LocationSelect = props => {
 
         const tolerance =
           area(selectedOption.value) / 10 ** 6 < 1000 ? 0.01 : 0.1;
-        const simplified_bounds = simplify(selectedOption.value, {
+        const simplified_geometry = simplify(selectedOption.value, {
           tolerance: tolerance,
           highQuality: true
         });
 
+        onChange(
+          'geometry',
+          fromJS([{ label: simplified_geometry, value: simplified_geometry }])
+        );
+        onChange('in_bbox', null);
+
         updateMap(
-          truncate(simplified_bounds, { precision: 6, coordinates: 2 })
+          truncate(simplified_geometry, { precision: 6, coordinates: 2 })
         );
       }
     },


### PR DESCRIPTION
Fixes #800. The code wasn't calling `onChange` when a location was selected from the search bar, so even though the location appeared on the map, it wasn't being added to the filter parameters upon saving.