### PR TITLE
Filter: Update wording for teams; remove teams list

### DIFF
--- a/src/config/filters.json
+++ b/src/config/filters.json
@@ -228,10 +228,9 @@
     "all": false,
     "range": false,
     "display": "Mapping teams",
-    "data_url": "mapping-team",
     "type": "text_comma",
-    "description": "Show changesets created by users that are part of a Mapping Team. Start typing to select one or more teams.",
-    "placeholder": "Enter mapping teams"
+    "description": "Show changesets created by users that are part of a Mapping Team. Type the team name as listed on your Teams page and use tab to confirm or add another team name.",
+    "placeholder": "Enter mapping team names"
   },
   {
     "name": "exclude_teams",
@@ -239,10 +238,9 @@
     "all": false,
     "range": false,
     "display": "Hide mapping teams",
-    "data_url": "mapping-team",
     "type": "text_comma",
-    "description": "Exclude changesets created by users that are part of a Mapping Team. Start typing to select one or more teams.",
-    "placeholder": "Enter mapping teams"
+    "description": "Exclude changesets created by users that are part of a Mapping Team. Type the team name as listed on your Teams page and use tab to confirm or add another team name.",
+    "placeholder": "Enter mapping team names"
   },
   {
     "name": "exclude_trusted_teams",


### PR DESCRIPTION
Related to https://github.com/OSMCha/osmcha-frontend/issues/653

Similar wording to https://github.com/OSMCha/osmcha-frontend/pull/817/files

I did not run this PR locally. But it should remove the dropdown and the (not useful) request that is done now, see https://github.com/OSMCha/osmcha-frontend/issues/653#issuecomment-3045636246. Instead this is a regular `text_comma` field now which allows to write out the team name as specified on the [/teams](https://osmcha.org/teams) page.

This keeps the feature … but works around the current issue with the pagination/search.