### PR TITLE
Make date filters use local time, not UTC

### DIFF
--- a/src/components/filters/date.tsx
+++ b/src/components/filters/date.tsx
@@ -1,4 +1,3 @@
-import { format, parse } from "date-fns";
 import React from "react";
 import DatePicker from "react-datepicker";
 import type { Filter } from "./index.ts";
@@ -13,28 +12,43 @@ interface DateFieldProps {
   value: Filter;
   className: string;
   onChange: (a: string, value?: Filter) => any;
-  min?: string;
-  max?: string;
+  min?: Date;
+  max?: Date;
+}
+
+// Parse a stored UTC timestamp to a local Date for display.
+export function parseStoredDate(value?: string): Date | null {
+  if (!value) return null;
+  let s = value.trim().replace(" ", "T");
+  if (/^\d{4}-\d{2}-\d{2}$/.test(s)) {
+    s += "T00:00:00Z";
+  } else if (
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(s) &&
+    !s.endsWith("Z") &&
+    !/[+-]\d{2}:\d{2}$/.test(s)
+  ) {
+    // Has time but no timezone indicator — treat as UTC (old format).
+    s += "Z";
+  }
+  const d = new Date(s);
+  return Number.isNaN(d.getTime()) ? null : d;
 }
 
 export class DateField extends React.Component<DateFieldProps> {
   static defaultProps = {
     className: "",
   };
+
   handleDateChange = (date: Date | null) => {
     const name = this.props.name;
     if (date) {
-      const value = format(date, "yyyy-MM-dd");
-      this.props.onChange(name, [
-        {
-          label: value,
-          value,
-        },
-      ]);
+      const value = date.toISOString();
+      this.props.onChange(name, [{ label: value, value }]);
     } else {
       this.props.onChange(name);
     }
   };
+
   render() {
     const { placeholder, display, value, className, min, max } = this.props;
     const dateValue = value?.[0]?.value;
@@ -44,14 +58,14 @@ export class DateField extends React.Component<DateFieldProps> {
         isClearable={true}
         selected={
           dateValue && typeof dateValue === "string"
-            ? parse(dateValue, "yyyy-MM-dd", new Date())
+            ? parseStoredDate(dateValue)
             : null
         }
         placeholderText={placeholder || display}
         onChange={this.handleDateChange}
         dateFormat="yyyy-MM-dd"
-        minDate={min ? new Date(min) : undefined}
-        maxDate={max ? new Date(max) : undefined}
+        minDate={min}
+        maxDate={max}
       />
     );
   }

--- a/src/components/filters/filters_list.tsx
+++ b/src/components/filters/filters_list.tsx
@@ -1,3 +1,4 @@
+import { startOfDay } from "date-fns";
 import React from "react";
 import filters from "../../config/filters.json";
 import { getDefaultFromDate } from "../../utils/filters.ts";
@@ -9,6 +10,7 @@ import {
   MappingTeamMultiSelect,
   Meta,
   MultiSelect,
+  parseStoredDate,
   Radio,
   Text,
   Wrapper,
@@ -98,7 +100,9 @@ class _FiltersList extends React.PureComponent<Props> {
         gteValue = this.props.filters[f.name + "__gte"] || defaultDate;
       }
       const lteValue = this.props.filters[f.name + "__lte"];
-      const today = new Date().toISOString().split("T")[0];
+      const today = startOfDay(new Date());
+      const gteDate = parseStoredDate(gteValue?.[0]?.value) ?? undefined;
+      const lteDate = parseStoredDate(lteValue?.[0]?.value) ?? undefined;
       return (
         <Wrapper
           {...wrapperProps}
@@ -114,7 +118,7 @@ class _FiltersList extends React.PureComponent<Props> {
               value={gteValue}
               className="mr3"
               placeholder={"From"}
-              max={lteValue?.[0]?.value || today}
+              max={lteDate || today}
             />
             <DateField
               {...propsToSend}
@@ -122,7 +126,7 @@ class _FiltersList extends React.PureComponent<Props> {
               value={lteValue}
               className="ml3"
               placeholder={"To"}
-              min={gteValue?.[0]?.value}
+              min={gteDate}
               max={today}
             />
           </span>

--- a/src/components/filters/index.ts
+++ b/src/components/filters/index.ts
@@ -1,4 +1,4 @@
-export { DateField } from "./date.tsx";
+export { DateField, parseStoredDate } from "./date.tsx";
 export { LocationSelect } from "./location.tsx";
 export { Meta } from "./meta.tsx";
 export { MappingTeamMultiSelect, MultiSelect } from "./multi_select.tsx";

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -1,4 +1,4 @@
-import { format, sub } from "date-fns";
+import { startOfDay, sub } from "date-fns";
 import { DEFAULT_FROM_DATE, DEFAULT_TO_DATE } from "../config/constants.ts";
 
 export function validateFilters(filters: any): boolean {
@@ -38,35 +38,19 @@ export function validateFilters(filters: any): boolean {
 }
 
 export function getDefaultFromDate(extraDays = 0): any {
-  const defaultDate = format(
+  const localMidnight = startOfDay(
     sub(new Date(), { days: DEFAULT_FROM_DATE + extraDays }),
-    "yyyy-MM-dd",
   );
+  const value = localMidnight.toISOString();
   return {
-    date__gte: [
-      {
-        label: defaultDate,
-        value: defaultDate,
-      },
-    ],
+    date__gte: [{ label: value, value }],
   };
 }
 
 function getDefaultToDate(): any {
-  const now = new Date();
-  const defaultDate = format(
-    sub(new Date(now.getTime() + now.getTimezoneOffset() * 60 * 1000), {
-      minutes: DEFAULT_TO_DATE,
-    }),
-    "yyyy-MM-dd HH:mm",
-  );
+  const value = sub(new Date(), { minutes: DEFAULT_TO_DATE }).toISOString();
   return {
-    date__lte: [
-      {
-        label: "",
-        value: defaultDate,
-      },
-    ],
+    date__lte: [{ label: "", value }],
   };
 }
 


### PR DESCRIPTION
This PR changes the filters page so that the selected "from" and "to" dates are interpreted in the user's local timezone, not UTC.

The backend `GET /api/v1/changesets` API will accept `date__lte` and `date__gte` filters with time components, but only in UTC, so the fix is to have the UI convert the selected dates to UTC timestamps (and to convert UTC timestamps from the filter URL to local time when the page loads).

I'm pretty sure this should fix #888.