### PR TITLE
Disable sort order dropdown when an AOI filter is active

### DIFF
--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -22,9 +22,9 @@ export function Button({
       title={title}
       className={`${
         className || ""
-      } btn btn--s border border--1 border--darken5 border--darken25-on-hover round bg-darken10 bg-darken5-on-hover color-gray transition ${
-        iconName && children ? "pl12 pr6" : ""
-      }`}
+      } btn btn--s border border--1 border--darken5 border--darken25-on-hover round bg-darken10 bg-darken5-on-hover transition ${
+        disabled ? "" : "color-gray"
+      } ${iconName && children ? "pl12 pr6" : ""}`}
     >
       {children}
       {iconName && (

--- a/src/components/dropdown.tsx
+++ b/src/components/dropdown.tsx
@@ -12,6 +12,7 @@ export interface DropdownOption {
 interface DropdownProps {
   className?: string;
   disabled?: boolean;
+  title?: string;
   value?: DropdownOption[];
   onChange?: (value: DropdownOption[]) => void;
   onAdd?: (option: DropdownOption) => void;
@@ -150,6 +151,7 @@ function DropdownContent({
 export function Dropdown({
   className = "",
   disabled,
+  title,
   value = [],
   onChange = () => {},
   onAdd = () => {},
@@ -190,7 +192,11 @@ export function Dropdown({
   }, [isOpen]);
 
   return (
-    <div ref={dropdownRef} className={`dropdown pointer ${className}`}>
+    <div
+      ref={dropdownRef}
+      className={`dropdown pointer ${className}`}
+      title={title}
+    >
       <Button
         iconName="chevron-down"
         onClick={toggleDropdown}

--- a/src/components/list/header.tsx
+++ b/src/components/list/header.tsx
@@ -6,6 +6,8 @@ import { Dropdown } from "../dropdown.tsx";
 
 interface HeaderProps {
   filters: any;
+  aoiId: string | null;
+  aoiOrderBy: string | null;
   handleFilterOrderBy: (value: any) => void;
   location: {
     search: string;
@@ -21,6 +23,8 @@ interface HeaderProps {
 
 export function Header({
   filters,
+  aoiId,
+  aoiOrderBy,
   handleFilterOrderBy,
   location,
   diffLoading,
@@ -31,11 +35,10 @@ export function Header({
   const valueData: any[] = [];
   const orderByFilter = filtersConfig.find((f) => f.name === "order_by");
   const options = orderByFilter?.options ?? [];
-  const orderByValue = filters?.order_by;
-  if (orderByValue) {
-    const firstValue = orderByValue?.[0]?.value;
+  const effectiveOrderBy = aoiId ? aoiOrderBy : filters?.order_by?.[0]?.value;
+  if (effectiveOrderBy) {
     for (const o of options) {
-      if (firstValue === o.value) {
+      if (effectiveOrderBy === o.value) {
         valueData.push(o);
       }
     }
@@ -51,6 +54,12 @@ export function Header({
           options={options}
           display={valueData[0]?.label || "Order by"}
           position="left"
+          disabled={!!aoiId}
+          title={
+            aoiId
+              ? "Sort order is determined by the active saved filter"
+              : undefined
+          }
         />
         <NavLink
           style={({ isActive }) => ({

--- a/src/views/changesets_list.tsx
+++ b/src/views/changesets_list.tsx
@@ -12,6 +12,7 @@ import {
   REFRESH_CHANGESETS,
 } from "../config/bindings.ts";
 import { useFilters } from "../hooks/useFilters.ts";
+import { useAOI } from "../query/hooks/useAOI.ts";
 import { useChangesetsPage } from "../query/hooks/useChangesetsPage.ts";
 
 interface ChangesetsPageData {
@@ -27,6 +28,8 @@ function ChangesetsList() {
   const location = useLocation();
   const navigate = useNavigate();
   const { filters, aoiId, setFilters } = useFilters();
+  const { data: aoi } = useAOI(aoiId);
+  const aoiOrderBy = aoi?.properties?.filters?.order_by ?? null;
 
   const {
     data: currentPage,
@@ -133,6 +136,8 @@ function ChangesetsList() {
     <div className="flex-parent flex-parent--column changesets-list">
       <Header
         filters={filters}
+        aoiId={aoiId}
+        aoiOrderBy={aoiOrderBy}
         handleFilterOrderBy={handleFilterOrderBy}
         location={location}
         currentPage={page}


### PR DESCRIPTION
The AOI filter defines the sort order; it can't be changed by the user viewing the filter. Previously the order dropdown was still active but did nothing. This PR disables it (and adds an explanatory tooltip) when an AOI filter is active.

Fixes #890.